### PR TITLE
Swap homepage logo to black version for better visibility

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="assets/visia-logo-white.svg" width="600"/>
+  <img src="assets/visia-logo-black.svg" width="600"/>
   <div>&nbsp;</div>
 
 [![PyPI](https://img.shields.io/pypi/v/visdet)](https://pypi.org/project/visdet)


### PR DESCRIPTION
## Summary
Replaces the white logo with the black logo on the docs homepage for better visibility on the light background.

## Changes
- Updated `docs/index.md` to reference `assets/visia-logo-black.svg` instead of `assets/visia-logo-white.svg`

## Notes
- This branch is created directly from `master` with no other changes
- No conflicts expected as this is a simple single-line change