### PR TITLE
Remove badges and quick links section from docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,16 +2,6 @@
   <img src="assets/visia-logo-black.svg" width="600"/>
   <div>&nbsp;</div>
 
-[![PyPI](https://img.shields.io/pypi/v/visdet)](https://pypi.org/project/visdet)
-[![docs](https://img.shields.io/badge/docs-latest-blue)](https://binitai.github.io/visdet/)
-[![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/BinItAI/visdet/blob/main/LICENSE)
-
-[📘Documentation](https://binitai.github.io/visdet/) |
-[🛠️Installation](https://binitai.github.io/visdet/getting-started/installation/) |
-[👀Model Zoo](https://binitai.github.io/visdet/model-zoo/) |
-[🆕Update News](https://binitai.github.io/visdet/about/changelog/) |
-[🤔Reporting Issues](https://github.com/BinItAI/visdet/issues)
-
 </div>
 
 ## Introduction


### PR DESCRIPTION
Removes the PyPI, docs, and license badges along with the quick links navigation section from the documentation homepage.