### PR TITLE
fix: Correct preset directory path resolution

### DIFF
--- a/visdet/presets/registry.py
+++ b/visdet/presets/registry.py
@@ -141,8 +141,8 @@ class PresetRegistry:
 
 def _get_preset_root() -> Path:
     """Get the root configs/presets directory."""
-    # visdet/visdet/presets/registry.py → visdet/ (repo root)
-    return Path(__file__).parent.parent.parent.parent / "configs" / "presets"
+    # visdet/presets/registry.py → . (repo root) → configs/presets
+    return Path(__file__).parent.parent.parent / "configs" / "presets"
 
 
 _PRESET_ROOT = _get_preset_root()


### PR DESCRIPTION
## Problem

The `_get_preset_root()` function in `visdet/presets/registry.py` was using incorrect path traversal, causing all preset registries to be empty.

## Root Cause

The code was traversing 4 parent directories instead of 3:
- **Was**: `Path(__file__).parent.parent.parent.parent` → goes to parent worktree directory
- **Should be**: `Path(__file__).parent.parent.parent` → goes to repo root

File path: `visdet/presets/registry.py`
- `.parent` → `visdet/presets/`
- `.parent.parent` → `visdet/`
- `.parent.parent.parent` → `.` (repo root) ← CORRECT

## Solution

Fixed path traversal to use 3 parents instead of 4.

## Impact

**Before**: All preset registries empty
- Models: 0
- Datasets: 0
- Optimizers: 0
- Schedulers: 0

**After**: Presets correctly discovered ✅
- Models: 1 (mask_rcnn_swin_s)
- Datasets: 2 (coco_instance_segmentation, cmr_instance_segmentation)
- Optimizers: 2 (adamw_8bit, adamw_default)
- Schedulers: 1 (1cycle)

## Files Changed

- `visdet/presets/registry.py` (2 lines: path traversal fix + comment update)

This is a minimal, focused fix for the preset discovery issue.