### PR TITLE
fix: Update preset YAML loader to use Config.fromfile()

### DIFF
--- a/visdet/presets/registry.py
+++ b/visdet/presets/registry.py
@@ -75,12 +75,12 @@ class PresetRegistry:
         if yaml_path is None:
             return self._cache[name].copy()
 
-        # Load YAML (uses _base_ and $ref resolution from config system)
-        from visdet.engine.config import load_yaml_config
+        # Load YAML using Config.fromfile (supports _base_ and config resolution)
+        from visdet.engine.config import Config
 
-        config = load_yaml_config(yaml_path)
+        config = Config.fromfile(str(yaml_path))
 
-        # Convert ConfigDict to plain dict and cache
+        # Convert Config/ConfigDict to plain dict and cache
         self._cache[name] = dict(config)
         return self._cache[name].copy()
 


### PR DESCRIPTION
## Problem

The preset registry was trying to import a non-existent `load_yaml_config()` function from `visdet.engine.config`.

## Root Cause

The function `load_yaml_config()` doesn't exist in the config module. The correct API is `Config.fromfile()`.

## Solution

Updated the YAML loading to use the correct `Config.fromfile()` method:
```python
# Before
from visdet.engine.config import load_yaml_config
config = load_yaml_config(yaml_path)

# After
from visdet.engine.config import Config
config = Config.fromfile(str(yaml_path))
```

## Note

`Config.fromfile()` currently fails with `ModuleNotFoundError: No module named 'visengine'` when trying to load preset files. This appears to be a separate issue with the config loading system that requires further investigation.

## Files Changed

- `visdet/presets/registry.py` (updated YAML loading code)