### PR TITLE
chore: scoped zuban typecheck for visdet/utils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
         pass_filenames: false
         files: ^visdet/core/mask/
 
+      - id: zuban-utils
+        name: Zuban type checker (visdet/utils)
+        entry: uv run zuban check visdet/utils
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/utils/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/visdet/utils/setup_env.py
+++ b/visdet/utils/setup_env.py
@@ -27,11 +27,12 @@ def register_all_modules(init_default_scope: bool = True) -> None:
     import visdet.visualization  # type: ignore # noqa: F401
 
     if init_default_scope:
-        never_created = DefaultScope.get_current_instance() is None or not DefaultScope.check_instance_created("visdet")
+        current_scope = DefaultScope.get_current_instance()
+        never_created = current_scope is None or not DefaultScope.check_instance_created("visdet")
         if never_created:
             DefaultScope.get_instance("visdet", scope_name="visdet")
             return
-        current_scope = DefaultScope.get_current_instance()
+        assert current_scope is not None
         if current_scope.scope_name != "visdet":
             warnings.warn(
                 "The current default scope "


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/utils`.

Also fixes a small `DefaultScope.get_current_instance()` None-handling issue so:
- `uv run zuban check visdet/utils` passes locally.