### PR TITLE
chore: scoped zuban typecheck for visdet/core/bbox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         pass_filenames: false
         files: ^visdet/apis/
 
+      - id: zuban-core-bbox
+        name: Zuban type checker (visdet/core/bbox)
+        entry: uv run zuban check visdet/core/bbox
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/core/bbox/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/visdet/core/bbox/demodata.py
+++ b/visdet/core/bbox/demodata.py
@@ -4,8 +4,10 @@
 # These are test utilities - provide stubs or imports if they exist
 # TODO: Check if these exist in the codebase
 
+from typing import Any
 
-def ensure_rng(rng=None):
+
+def ensure_rng(rng: Any = None) -> Any:
     """Ensure we have a random number generator."""
     import numpy as np
 


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/core/bbox`.

Also adds a small `ensure_rng` type annotation so:
- `uv run zuban check visdet/core/bbox` passes locally.