### PR TITLE
docs: add tests status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
   <p>
     <a href="https://pypi.org/project/visdet"><img src="https://img.shields.io/pypi/v/visdet?style=flat-square&color=blue" alt="PyPI"/></a>
+    <a href="https://github.com/BinItAI/visdet/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/BinItAI/visdet/test.yml?branch=main&style=flat-square" alt="Tests"/></a>
     <a href="https://binitai.github.io/visdet/"><img src="https://img.shields.io/badge/docs-latest-brightgreen?style=flat-square" alt="Documentation"/></a>
   </p>
 


### PR DESCRIPTION
Adds a GitHub Actions "Tests" status badge to the README so CI status is visible at a glance.