### PR TITLE
chore: scoped zuban typecheck for visdet/evaluation/evaluator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         pass_filenames: false
         files: ^visdet/apis/
 
+      - id: zuban-eval-evaluator
+        name: Zuban type checker (visdet/evaluation/evaluator)
+        entry: uv run zuban check visdet/evaluation/evaluator
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/evaluation/evaluator/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/evaluation/evaluator`.

- `uv run zuban check visdet/evaluation/evaluator` passes locally.