### PR TITLE
chore: scoped zuban typecheck for visdet/engine/registry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         pass_filenames: false
         files: ^visdet/apis/
 
+      - id: zuban-engine-registry
+        name: Zuban type checker (visdet/engine/registry)
+        entry: uv run zuban check visdet/engine/registry
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/registry/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/registry`.

- `uv run zuban check visdet/engine/registry` passes locally.