### PR TITLE
chore: scoped zuban typecheck for visdet/engine/logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         pass_filenames: false
         files: ^visdet/apis/
 
+      - id: zuban-engine-logging
+        name: Zuban type checker (visdet/engine/logging)
+        entry: uv run zuban check visdet/engine/logging
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/logging/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/logging`.

- `uv run zuban check visdet/engine/logging` passes locally.