### PR TITLE
chore: scoped zuban typecheck for visdet/engine/_strategy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
         pass_filenames: false
         files: ^visdet/core/mask/
 
+      - id: zuban-engine-strategy
+        name: Zuban type checker (visdet/engine/_strategy)
+        entry: uv run zuban check visdet/engine/_strategy
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/_strategy/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/_strategy`.

- `uv run zuban check visdet/engine/_strategy` passes locally.