### PR TITLE
chore: scoped zuban typecheck for visdet/engine/evaluator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
         pass_filenames: false
         files: ^visdet/core/mask/
 
+      - id: zuban-engine-evaluator
+        name: Zuban type checker (visdet/engine/evaluator)
+        entry: uv run zuban check visdet/engine/evaluator
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/evaluator/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/evaluator`.

- `uv run zuban check visdet/engine/evaluator` passes locally.