### PR TITLE
chore: scoped zuban typecheck for visdet/engine/infer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
         pass_filenames: false
         files: ^visdet/core/mask/
 
+      - id: zuban-engine-infer
+        name: Zuban type checker (visdet/engine/infer)
+        entry: uv run zuban check visdet/engine/infer
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/infer/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/infer`.

- `uv run zuban check visdet/engine/infer` passes locally.