### PR TITLE
chore: scoped zuban typecheck for visdet/engine/optimizers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,14 @@ repos:
         pass_filenames: false
         files: ^visdet/core/mask/
 
+      - id: zuban-engine-optimizers
+        name: Zuban type checker (visdet/engine/optimizers)
+        entry: uv run zuban check visdet/engine/optimizers
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/optimizers/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/optimizers`.

- `uv run zuban check visdet/engine/optimizers` passes locally.