### PR TITLE
chore: scoped zuban typecheck for visdet/engine/dist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,14 @@ repos:
         pass_filenames: false
         files: ^visdet/engine/optimizers/
 
+      - id: zuban-engine-dist
+        name: Zuban type checker (visdet/engine/dist)
+        entry: uv run zuban check visdet/engine/dist
+        language: system
+        types: [python]
+        pass_filenames: false
+        files: ^visdet/engine/dist/
+
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/visdet/engine/dist/__init__.py
+++ b/visdet/engine/dist/__init__.py
@@ -70,7 +70,7 @@ def barrier():
         dist_lib.barrier()
 
 
-def broadcast(data, src=0, group=None):
+def broadcast(data: Any, src: int = 0, group: Any | None = None) -> Any:
     """Broadcast data from src rank to all ranks."""
     if not _is_dist_available_and_initialized():
         return data
@@ -109,7 +109,7 @@ def all_reduce_params(model):
             param.grad.data.div_(world_size)
 
 
-def init_dist(launcher='pytorch', backend='nccl', **kwargs):
+def init_dist(launcher: str = "pytorch", backend: str = "nccl", **kwargs: Any) -> tuple[int, int]:
     """Initialize distributed environment."""
     if _is_dist_available_and_initialized():
         return get_dist_info()


### PR DESCRIPTION
Adds a Zuban pre-commit hook scoped to `visdet/engine/dist`.

Also adds a couple of small annotations to avoid Zuban unreachable warnings so:
- `uv run zuban check visdet/engine/dist` passes locally.