### PR TITLE
feat: add RetinaNet support

### DIFF
--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -631,6 +631,8 @@ def test_inference_detector():
 
     model = build_detector(ConfigDict(model_dict))
     config = _get_config_module("retinanet/retinanet_r50_fpn_1x_coco.py")
+    # Add mock test_dataloader to avoid AttributeError in inference_detector
+    config.test_dataloader = ConfigDict(dataset=ConfigDict(pipeline=config.test_pipeline))
     model.cfg = config
     # test single image
     result = inference_detector(model, img1)

--- a/tests/test_models/test_retinanet.py
+++ b/tests/test_models/test_retinanet.py
@@ -1,0 +1,106 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+import torch.nn as nn
+from visdet.structures import DetDataSample, InstanceData
+from visdet.registry import MODELS
+
+
+def test_retinanet_forward_backward():
+    model_cfg = dict(
+        type="RetinaNet",
+        backbone=dict(
+            type="ResNet",
+            depth=18,
+            num_stages=4,
+            out_indices=(0, 1, 2, 3),
+            frozen_stages=1,
+            norm_cfg=dict(type="BN", requires_grad=True),
+            norm_eval=True,
+            style="pytorch",
+        ),
+        neck=dict(
+            type="FPN",
+            in_channels=[64, 128, 256, 512],
+            out_channels=256,
+            start_level=1,
+            add_extra_convs="on_input",
+            num_outs=5,
+        ),
+        bbox_head=dict(
+            type="RetinaHead",
+            num_classes=80,
+            in_channels=256,
+            stacked_convs=4,
+            feat_channels=256,
+            anchor_generator=dict(
+                type="AnchorGenerator",
+                octave_base_scale=4,
+                scales_per_octave=3,
+                ratios=[0.5, 1.0, 2.0],
+                strides=[8, 16, 32, 64, 128],
+            ),
+            bbox_coder=dict(
+                type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[1.0, 1.0, 1.0, 1.0]
+            ),
+            loss_cls=dict(type="FocalLoss", use_sigmoid=True, gamma=2.0, alpha=0.25, loss_weight=1.0),
+            loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+        ),
+        train_cfg=dict(
+            assigner=dict(type="MaxIoUAssigner", pos_iou_thr=0.5, neg_iou_thr=0.4, min_pos_iou=0, ignore_iof_thr=-1),
+            allowed_border=-1,
+            pos_weight=-1,
+            debug=False,
+        ),
+        test_cfg=dict(
+            nms_pre=1000, min_bbox_size=0, score_thr=0.05, nms=dict(type="nms", iou_threshold=0.5), max_per_img=100
+        ),
+    )
+
+    detector = MODELS.build(model_cfg)
+
+    # Test forward train
+    imgs = torch.randn(2, 3, 224, 224, requires_grad=True)
+    data_samples = []
+    for i in range(2):
+        data_sample = DetDataSample()
+        data_sample.set_metainfo(
+            dict(img_shape=(224, 224), ori_shape=(224, 224), pad_shape=(224, 224), scale_factor=(1.0, 1.0))
+        )
+        gt_instances = InstanceData()
+        gt_instances.bboxes = torch.tensor([[10, 10, 50, 50]], dtype=torch.float32)
+        gt_instances.labels = torch.tensor([1], dtype=torch.long)
+        data_sample.gt_instances = gt_instances
+        data_samples.append(data_sample)
+
+    # Mode loss
+    losses = detector(imgs, data_samples, mode="loss")
+    assert isinstance(losses, dict)
+    assert "loss_cls" in losses
+    assert "loss_bbox" in losses
+
+    # Backward pass
+    total_loss = 0
+    for loss_value in losses.values():
+        if isinstance(loss_value, torch.Tensor):
+            total_loss += loss_value.sum()
+        elif isinstance(loss_value, list):
+            total_loss += sum(l.sum() for l in loss_value)
+
+    total_loss.backward()
+    assert imgs.grad is not None
+    print("Backward pass passed!")
+
+    # Test forward predict
+    detector.eval()
+    with torch.no_grad():
+        predictions = detector(imgs, data_samples, mode="predict")
+        assert len(predictions) == 2
+        assert isinstance(predictions[0], DetDataSample)
+        assert hasattr(predictions[0], "pred_instances")
+    print("Forward predict passed!")
+
+    print("RetinaNet forward and backward tests passed!")
+
+
+if __name__ == "__main__":
+    test_retinanet_forward_backward()

--- a/visdet/models/dense_heads/__init__.py
+++ b/visdet/models/dense_heads/__init__.py
@@ -2,5 +2,6 @@
 from visdet.models.dense_heads.base_dense_head import BaseDenseHead
 from visdet.models.dense_heads.anchor_head import AnchorHead
 from visdet.models.dense_heads.rpn_head import RPNHead
+from visdet.models.dense_heads.retina_head import RetinaHead
 
-__all__ = ["BaseDenseHead", "AnchorHead", "RPNHead"]
+__all__ = ["BaseDenseHead", "AnchorHead", "RPNHead", "RetinaHead"]

--- a/visdet/models/dense_heads/base_dense_head.py
+++ b/visdet/models/dense_heads/base_dense_head.py
@@ -466,18 +466,19 @@ class BaseDenseHead(BaseModule, metaclass=ABCMeta):
         # filter small size bboxes
         if cfg.get("min_bbox_size", -1) >= 0:
             w, h = get_box_wh(results.bboxes)
-            valid_mask = (w > cfg.min_bbox_size) & (h > cfg.min_bbox_size)
+            min_bbox_size = cfg.get("min_bbox_size")
+            valid_mask = (w > min_bbox_size) & (h > min_bbox_size)
             if not valid_mask.all():
                 results = results[valid_mask]
 
         # TODO: deal with `with_nms` and `nms_cfg=None` in test_cfg
         if with_nms and results.bboxes.numel() > 0:
             bboxes = get_box_tensor(results.bboxes)
-            det_bboxes, keep_idxs = batched_nms(bboxes, results.scores, results.labels, cfg.nms)
+            det_bboxes, keep_idxs = batched_nms(bboxes, results.scores, results.labels, cfg.get("nms"))
             results = results[keep_idxs]
             # some nms would reweight the score, such as softnms
             results.scores = det_bboxes[:, -1]
-            results = results[: cfg.max_per_img]
+            results = results[: cfg.get("max_per_img")]
 
         return results
 

--- a/visdet/models/dense_heads/retina_head.py
+++ b/visdet/models/dense_heads/retina_head.py
@@ -1,0 +1,101 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch.nn as nn
+from visdet.cv.cnn import ConvModule
+
+from visdet.registry import MODELS
+from .anchor_head import AnchorHead
+
+
+@MODELS.register_module()
+class RetinaHead(AnchorHead):
+    """An anchor-based head used in `RetinaNet
+    <https://arxiv.org/abs/1708.02002>`_.
+
+    The head contains two separate stacks of convolution layers, one for
+    classification and one for localization. Each stack has four conv layers
+    with a 3x3 kernel and 256 channels.
+
+    Args:
+        stacked_convs (int): Number of stacking conv layers of the head.
+            Defaults to 4.
+        conv_cfg (dict): Config dict for convolution layer.
+            Defaults to None.
+        norm_cfg (dict): Config dict for normalization layer.
+            Defaults to None.
+        init_cfg (dict or list[dict], optional): Initialization config dict.
+    """
+
+    def __init__(
+        self,
+        num_classes,
+        in_channels,
+        stacked_convs=4,
+        conv_cfg=None,
+        norm_cfg=None,
+        init_cfg=dict(
+            type="Normal",
+            layer="Conv2d",
+            std=0.01,
+            override=dict(type="Normal", name="retina_cls", std=0.01, bias_prob=0.01),
+        ),
+        **kwargs,
+    ):
+        self.stacked_convs = stacked_convs
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        super().__init__(num_classes, in_channels, init_cfg=init_cfg, **kwargs)
+
+    def _init_layers(self):
+        """Initialize layers of the head."""
+        self.relu = nn.ReLU(inplace=True)
+        self.cls_convs = nn.ModuleList()
+        self.reg_convs = nn.ModuleList()
+        for i in range(self.stacked_convs):
+            chn = self.in_channels if i == 0 else self.feat_channels
+            self.cls_convs.append(
+                ConvModule(
+                    chn,
+                    self.feat_channels,
+                    3,
+                    stride=1,
+                    padding=1,
+                    conv_cfg=self.conv_cfg,
+                    norm_cfg=self.norm_cfg,
+                )
+            )
+            self.reg_convs.append(
+                ConvModule(
+                    chn,
+                    self.feat_channels,
+                    3,
+                    stride=1,
+                    padding=1,
+                    conv_cfg=self.conv_cfg,
+                    norm_cfg=self.norm_cfg,
+                )
+            )
+        self.retina_cls = nn.Conv2d(self.feat_channels, self.num_base_priors * self.cls_out_channels, 3, padding=1)
+        self.retina_reg = nn.Conv2d(self.feat_channels, self.num_base_priors * 4, 3, padding=1)
+
+    def forward_single(self, x):
+        """Forward feature of a single scale level.
+
+        Args:
+            x (Tensor): Features of a single scale level.
+
+        Returns:
+            tuple:
+                cls_score (Tensor): Cls scores for a single scale level
+                    the channels number is num_base_priors * num_classes.
+                bbox_pred (Tensor): Box energies / deltas for a single scale
+                    level, the channels number is num_base_priors * 4.
+        """
+        cls_feat = x
+        reg_feat = x
+        for cls_conv in self.cls_convs:
+            cls_feat = cls_conv(cls_feat)
+        for reg_conv in self.reg_convs:
+            reg_feat = reg_conv(reg_feat)
+        cls_score = self.retina_cls(cls_feat)
+        bbox_pred = self.retina_reg(reg_feat)
+        return cls_score, bbox_pred

--- a/visdet/models/detectors/__init__.py
+++ b/visdet/models/detectors/__init__.py
@@ -4,6 +4,8 @@
 from visdet.models.detectors.base import BaseDetector
 from visdet.models.detectors.cascade_rcnn import CascadeRCNN
 from visdet.models.detectors.mask_rcnn import MaskRCNN
+from visdet.models.detectors.retinanet import RetinaNet
+from visdet.models.detectors.single_stage import SingleStageDetector
 from visdet.models.detectors.two_stage import TwoStageDetector
 
-__all__ = ["BaseDetector", "TwoStageDetector", "MaskRCNN", "CascadeRCNN"]
+__all__ = ["BaseDetector", "SingleStageDetector", "TwoStageDetector", "RetinaNet", "MaskRCNN", "CascadeRCNN"]

--- a/visdet/models/detectors/retinanet.py
+++ b/visdet/models/detectors/retinanet.py
@@ -1,0 +1,28 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from visdet.registry import MODELS
+from .single_stage import SingleStageDetector
+
+
+@MODELS.register_module()
+class RetinaNet(SingleStageDetector):
+    """Implementation of `RetinaNet <https://arxiv.org/abs/1708.02002>`_"""
+
+    def __init__(
+        self,
+        backbone,
+        neck,
+        bbox_head,
+        train_cfg=None,
+        test_cfg=None,
+        data_preprocessor=None,
+        init_cfg=None,
+    ):
+        super().__init__(
+            backbone=backbone,
+            neck=neck,
+            bbox_head=bbox_head,
+            train_cfg=train_cfg,
+            test_cfg=test_cfg,
+            data_preprocessor=data_preprocessor,
+            init_cfg=init_cfg,
+        )

--- a/visdet/models/detectors/single_stage.py
+++ b/visdet/models/detectors/single_stage.py
@@ -1,0 +1,119 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from torch import Tensor
+
+from visdet.registry import MODELS
+from visdet.utils.typing_utils import ConfigType, OptConfigType, OptMultiConfig
+from .base import BaseDetector, SampleList
+
+
+@MODELS.register_module()
+class SingleStageDetector(BaseDetector):
+    """Base class for single-stage detectors.
+
+    Single-stage detectors directly and densely predict bounding boxes on the
+    output features of the backbone+neck.
+    """
+
+    def __init__(
+        self,
+        backbone: ConfigType,
+        neck: OptConfigType = None,
+        bbox_head: OptConfigType = None,
+        train_cfg: OptConfigType = None,
+        test_cfg: OptConfigType = None,
+        data_preprocessor: OptConfigType = None,
+        init_cfg: OptMultiConfig = None,
+    ) -> None:
+        super().__init__(data_preprocessor=data_preprocessor, init_cfg=init_cfg)
+        self.backbone = MODELS.build(backbone)
+        if neck is not None:
+            self.neck = MODELS.build(neck)
+        bbox_head.update(train_cfg=train_cfg)
+        bbox_head.update(test_cfg=test_cfg)
+        self.bbox_head = MODELS.build(bbox_head)
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
+
+    def extract_feat(self, batch_inputs: Tensor) -> tuple[Tensor]:
+        """Extract features.
+
+        Args:
+            batch_inputs (Tensor): Image tensor with shape (N, C, H ,W).
+
+        Returns:
+            tuple[Tensor]: Multi-level features that may have
+            different resolutions.
+        """
+        x = self.backbone(batch_inputs)
+        if self.with_neck:
+            x = self.neck(x)
+        return x
+
+    def loss(self, batch_inputs: Tensor, batch_data_samples: SampleList) -> dict:
+        """Calculate losses from a batch of inputs and data samples.
+
+        Args:
+            batch_inputs (Tensor): Input images of shape (N, C, H, W).
+                These should usually be mean centered and std scaled.
+            batch_data_samples (list[:obj:`DetDataSample`]): The batch
+                data samples. It usually includes information such
+                as `gt_instance` or `gt_panoptic_seg` or `gt_sem_seg`.
+
+        Returns:
+            dict: A dictionary of loss components
+        """
+        x = self.extract_feat(batch_inputs)
+        losses = self.bbox_head.loss(x, batch_data_samples)
+        return losses
+
+    def predict(
+        self,
+        batch_inputs: Tensor,
+        batch_data_samples: SampleList,
+        rescale: bool = True,
+    ) -> SampleList:
+        """Predict results from a batch of inputs and data samples with post-
+        processing.
+
+        Args:
+            batch_inputs (Tensor): Inputs with shape (N, C, H, W).
+            batch_data_samples (list[:obj:`DetDataSample`]): The Data
+                Samples. It usually includes information such as
+                `gt_instance`, `gt_panoptic_seg` and `gt_sem_seg`.
+            rescale (bool): Whether to rescale the results.
+                Defaults to True.
+
+        Returns:
+            list[:obj:`DetDataSample`]: Return the detection results of the
+            input images. The returns value is DetDataSample,
+            which usually contain 'pred_instances'. And the
+            ``pred_instances`` usually contains following keys.
+
+                - scores (Tensor): Classification scores, has a shape
+                    (num_instance, )
+                - labels (Tensor): Labels of bboxes, has a shape
+                    (num_instances, ).
+                - bboxes (Tensor): Has a shape (num_instances, 4),
+                    the last dimension 4 arrange as (x1, y1, x2, y2).
+        """
+        x = self.extract_feat(batch_inputs)
+        results_list = self.bbox_head.predict(x, batch_data_samples, rescale=rescale)
+        batch_data_samples = self.add_pred_to_datasample(batch_data_samples, results_list)
+        return batch_data_samples
+
+    def _forward(self, batch_inputs: Tensor, batch_data_samples: SampleList | None = None) -> tuple:
+        """Network forward process. Usually includes backbone, neck and head
+        forward without any post-processing.
+
+        Args:
+            batch_inputs (Tensor): Inputs with shape (N, C, H, W).
+            batch_data_samples (list[:obj:`DetDataSample`]): Each item contains
+                the meta information of each image and corresponding
+                annotations.
+
+        Returns:
+            tuple: A tuple of features from ``bbox_head`` forward.
+        """
+        x = self.extract_feat(batch_inputs)
+        results = self.bbox_head.forward(x)
+        return results

--- a/visdet/models/losses/__init__.py
+++ b/visdet/models/losses/__init__.py
@@ -2,5 +2,6 @@
 from visdet.models.losses.smooth_l1_loss import L1Loss, SmoothL1Loss
 from visdet.models.losses.accuracy import accuracy
 from visdet.models.losses.cross_entropy_loss import CrossEntropyLoss
+from visdet.models.losses.focal_loss import FocalLoss
 
-__all__ = ["CrossEntropyLoss", "L1Loss", "SmoothL1Loss", "accuracy"]
+__all__ = ["CrossEntropyLoss", "L1Loss", "SmoothL1Loss", "accuracy", "FocalLoss"]

--- a/visdet/models/losses/focal_loss.py
+++ b/visdet/models/losses/focal_loss.py
@@ -1,0 +1,153 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from visdet.registry import MODELS
+from .utils import weight_reduce_loss, weighted_loss
+
+
+@weighted_loss
+def py_sigmoid_focal_loss(
+    pred: Tensor,
+    target: Tensor,
+    gamma: float = 2.0,
+    alpha: float = 0.25,
+) -> Tensor:
+    """PyTorch version of `Focal Loss <https://arxiv.org/abs/1708.02002>`_.
+
+    Args:
+        pred (Tensor): The prediction with shape (N, C), C is the
+            number of classes
+        target (Tensor): The learning label of the prediction.
+        gamma (float, optional): The gamma for calculating the modulating
+            factor. Defaults to 2.0.
+        alpha (float, optional): A balanced form for Focal Loss.
+            Defaults to 0.25.
+
+    Returns:
+        Tensor: Loss tensor.
+    """
+    pred_sigmoid = pred.sigmoid()
+    target = target.type_as(pred)
+    pt = (1 - pred_sigmoid) * target + pred_sigmoid * (1 - target)
+    focal_weight = (alpha * target + (1 - alpha) * (1 - target)) * pt.pow(gamma)
+    loss = F.binary_cross_entropy_with_logits(pred, target, reduction="none") * focal_weight
+    return loss
+
+
+def focal_loss_weight_reshape(loss: Tensor, weight: Tensor | None) -> Tensor | None:
+    """Reshape weight to match the shape of loss."""
+    if weight is not None:
+        if weight.shape != loss.shape:
+            if weight.size(0) == loss.size(0):
+                # For most cases, weight is of shape (num_priors, ),
+                #  which means it does not have the second axis num_class
+                weight = weight.view(-1, 1)
+            else:
+                # Sometimes, weight per anchor per class is also needed. e.g.
+                #  in FSAF. But it may be flattened of shape
+                #  (num_priors x num_class, ), while loss is still of shape
+                #  (num_priors, num_class).
+                assert weight.numel() == loss.numel()
+                weight = weight.view(loss.size(0), -1)
+        assert weight.ndim == loss.ndim
+    return weight
+
+
+@MODELS.register_module()
+class FocalLoss(nn.Module):
+    def __init__(
+        self,
+        use_sigmoid: bool = True,
+        gamma: float = 2.0,
+        alpha: float = 0.25,
+        reduction: str = "mean",
+        loss_weight: float = 1.0,
+        activated: bool = False,
+    ) -> None:
+        """`Focal Loss <https://arxiv.org/abs/1708.02002>`_
+
+        Args:
+            use_sigmoid (bool, optional): Whether to the prediction is
+                used for sigmoid or softmax. Defaults to True.
+            gamma (float, optional): The gamma for calculating the modulating
+                factor. Defaults to 2.0.
+            alpha (float, optional): A balanced form for Focal Loss.
+                Defaults to 0.25.
+            reduction (str, optional): The method used to reduce the loss into
+                a scalar. Defaults to 'mean'. Options are "none", "mean" and
+                "sum".
+            loss_weight (float, optional): Weight of loss. Defaults to 1.0.
+            activated (bool, optional): Whether the input is activated.
+                If True, it means the input has been activated and can be
+                treated as probabilities. Else, it should be treated as logits.
+                Defaults to False.
+        """
+        super(FocalLoss, self).__init__()
+        assert use_sigmoid is True, "Only sigmoid focal loss supported now."
+        self.use_sigmoid = use_sigmoid
+        self.gamma = gamma
+        self.alpha = alpha
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+        self.activated = activated
+
+    def forward(
+        self,
+        pred: Tensor,
+        target: Tensor,
+        weight: Tensor | None = None,
+        avg_factor: int | None = None,
+        reduction_override: str | None = None,
+    ) -> Tensor:
+        """Forward function.
+
+        Args:
+            pred (Tensor): The prediction.
+            target (Tensor): The learning label of the prediction.
+            weight (Tensor, optional): The weight of loss for each
+                prediction. Defaults to None.
+            avg_factor (int, optional): Average factor that is used to average
+                the loss. Defaults to None.
+            reduction_override (str, optional): The reduction method used to
+                override the original reduction method of the loss.
+                Options are "none", "mean" and "sum".
+
+        Returns:
+            Tensor: The calculated loss
+        """
+        assert reduction_override in (None, "none", "mean", "sum")
+        reduction = reduction_override if reduction_override else self.reduction
+        if self.use_sigmoid:
+            if self.activated:
+                # TODO: implement py_focal_loss_with_prob if needed
+                raise NotImplementedError("activated=True is not supported yet")
+            else:
+                num_classes = pred.size(1)
+                target = F.one_hot(target, num_classes=num_classes + 1)
+                target = target[:, :num_classes].type_as(pred)
+
+                # Reshape weight if needed
+                if weight is not None:
+                    if weight.shape != pred.shape:
+                        if weight.size(0) == pred.size(0):
+                            weight = weight.view(-1, 1)
+                        else:
+                            assert weight.numel() == pred.numel()
+                            weight = weight.view(pred.size(0), -1)
+
+                loss_cls = self.loss_weight * py_sigmoid_focal_loss(
+                    pred,
+                    target,
+                    weight,
+                    gamma=self.gamma,
+                    alpha=self.alpha,
+                    reduction=reduction,
+                    avg_factor=avg_factor,
+                )
+
+        else:
+            raise NotImplementedError
+        return loss_cls


### PR DESCRIPTION
## Summary
- Implemented `SingleStageDetector` and `RetinaNet` detector.
- Implemented `RetinaHead` with multi-level anchor-based dense prediction.
- Ported `FocalLoss` from MMDetection (PyTorch version).
- Fixed `BaseDenseHead` to support dictionary-based `test_cfg` for better compatibility.
- Added forward and backward pass tests for RetinaNet.