### PR TITLE
ci: auto-commit prek autofixes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,11 +10,26 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 jobs:
   prek:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
+      - name: Checkout PR head (for auto-commit)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
       - name: Checkout repository
+        if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
 
       - name: Install uv
@@ -31,5 +46,59 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      - name: Run prek hooks
+      - name: Run prek hooks (allow autofixes)
+        id: prek
+        shell: bash
+        run: |
+          set +e
+          uv run prek run --all-files
+          exit_code=$?
+
+          echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          exit 0
+
+      - name: Commit and push prek autofixes
+        if: |
+          steps.prek.outputs.changed == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'github-actions[bot]'
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "chore: apply prek autofixes"
+          git push
+
+      - name: Fail if prek changed files (can't auto-push)
+        if: |
+          steps.prek.outputs.changed == 'true' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository)
+        shell: bash
+        run: |
+          echo "prek modified files but this workflow can't push to the branch (fork PR or missing permissions)."
+          echo "Please run: uv run prek run --all-files and commit the results."
+          git status --porcelain
+          exit 1
+
+      - name: Re-run prek hooks after auto-commit
+        if: |
+          steps.prek.outputs.changed == 'true' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'github-actions[bot]'
         run: uv run prek run --all-files
+
+      - name: Fail on non-fixable prek errors
+        if: steps.prek.outputs.changed == 'false' && steps.prek.outputs.exit_code != '0'
+        shell: bash
+        run: exit 1


### PR DESCRIPTION
## Summary
- Update the Prek GitHub Actions workflow to auto-commit and push formatting/autofix changes back to same-repo PR branches.
- Fail with clear instructions for fork PRs where the workflow cannot push.