### PR TITLE
Inference: default to all GPUs

### DIFF
--- a/tests/test_runtime/test_inference_device_parsing.py
+++ b/tests/test_runtime/test_inference_device_parsing.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 from visdet.apis import inference as inference_api
 
@@ -6,6 +7,20 @@ from visdet.apis import inference as inference_api
 def test_parse_inference_devices_single_device():
     assert inference_api._parse_inference_devices("cpu") == ("cpu", None)
     assert inference_api._parse_inference_devices("cuda:0") == ("cuda:0", None)
+
+
+def test_parse_inference_devices_auto_cuda():
+    primary, device_ids = inference_api._parse_inference_devices("cuda")
+
+    if not torch.cuda.is_available():
+        assert (primary, device_ids) == ("cpu", None)
+        return
+
+    assert primary == "cuda:0"
+    if torch.cuda.device_count() > 1:
+        assert device_ids == list(range(torch.cuda.device_count()))
+    else:
+        assert device_ids is None
 
 
 def test_parse_inference_devices_multi_device():


### PR DESCRIPTION
## Summary
- Change `init_detector(..., device=...)` default from `"cuda:0"` to `"cuda"`.
- When `device="cuda"`, auto-detect available GPUs and use all of them for single-process inference.
- Log an info message: `found X GPUs`.

## Testing
- `python3 -m pytest -q tests/test_runtime/test_inference_device_parsing.py`